### PR TITLE
Qualify type names that clash with members.

### DIFF
--- a/working-draft.html
+++ b/working-draft.html
@@ -971,22 +971,22 @@ system or for a particular file system.</p>
                   class Allocator = allocator&lt;EcharT&gt; &gt;
         basic_string&lt;EcharT, traits, Allocator&gt;
           <a href="#string-template">string</a>(const Allocator&amp; a = Allocator()) const;
-        string    <a href="#string">string</a>() const;
-        wstring   <a href="#wstring">wstring</a>() const;
-        string    <a href="#u8string">u8string</a>() const;
-        u16string <a href="#u16string">u16string</a>() const;
-        u32string <a href="#u32string">u32string</a>() const;
+        std::string    <a href="#string">string</a>() const;
+        std::wstring   <a href="#wstring">wstring</a>() const;
+        std::string    <a href="#u8string">u8string</a>() const;
+        std::u16string <a href="#u16string">u16string</a>() const;
+        std::u32string <a href="#u32string">u32string</a>() const;
 
         // <a href="#path-generic-format-observers">generic format observers</a>
         template &lt;class EcharT, class traits = char_traits&lt;EcharT&gt;,
                   class Allocator = allocator&lt;EcharT&gt; &gt;
         basic_string&lt;EcharT, traits, Allocator&gt;
           <a href="#generic_string-template">generic_string</a>(const Allocator&amp; a = Allocator()) const;
-        string    <a href="#generic_string">generic_string</a>() const;
-        wstring   <a href="#generic_wstring">generic_wstring</a>() const;
-        string    <a href="#generic_u8string">generic_u8string</a>() const;
-        u16string <a href="#generic_u16string">generic_u16string</a>() const;
-        u32string <a href="#generic_u32string">generic_u32string</a>() const;
+        std::string    <a href="#generic_string">generic_string</a>() const;
+        std::wstring   <a href="#generic_wstring">generic_wstring</a>() const;
+        std::string    <a href="#generic_u8string">generic_u8string</a>() const;
+        std::u16string <a href="#generic_u16string">generic_u16string</a>() const;
+        std::u32string <a href="#generic_u32string">generic_u32string</a>() const;
 
         // <a href="#path-compare">compare</a>
         int  <a href="#path-compare">compare</a>(const path&amp; p) const noexcept;
@@ -1506,11 +1506,11 @@ basic_string&lt;EcharT, traits, Allocator&gt;
 be performed by <code>a</code>. Conversion, if any, is specified by
 <a href="#path.cvt">8.2</a>.</p>
 </blockquote>
-<pre para_num="12">string <a name="string">string</a>() const;
-wstring <a name="wstring">wstring</a>() const;
-string <a name="u8string">u8string</a>() const;
-u16string <a name="u16string">u16string</a>() const;
-u32string <a name="u32string">u32string</a>() const; </pre>
+<pre para_num="12">std::string <a name="string">string</a>() const;
+std::wstring <a name="wstring">wstring</a>() const;
+std::string <a name="u8string">u8string</a>() const;
+std::u16string <a name="u16string">u16string</a>() const;
+std::u32string <a name="u32string">u32string</a>() const; </pre>
 <blockquote>
 <p para_num="13"><i>Returns:</i> <code>pathname</code>.</p>
 <p para_num="14"><i>Remarks:</i> Conversion, if any, is performed as specified 
@@ -1542,11 +1542,11 @@ basic_string&lt;EcharT, traits, Allocator&gt;
 be performed by <code>a</code>. Conversion, if any, is specified by
 <a href="#path.cvt">8.2</a>.</p>
 </blockquote>
-<pre para_num="6">string <a name="generic_string">generic_string</a>() const;
-wstring <a name="generic_wstring">generic_wstring</a>() const;
-string <a name="generic_u8string">generic_u8string</a>() const;
-u16string <a name="generic_u16string">generic_u16string</a>() const;
-u32string <a name="generic_u32string">generic_u32string</a>() const; </pre>
+<pre para_num="6">std::string <a name="generic_string">generic_string</a>() const;
+std::wstring <a name="generic_wstring">generic_wstring</a>() const;
+std::string <a name="generic_u8string">generic_u8string</a>() const;
+std::u16string <a name="generic_u16string">generic_u16string</a>() const;
+std::u32string <a name="generic_u32string">generic_u32string</a>() const; </pre>
 <blockquote>
 <p para_num="7"><i>Returns:</i> <code>pathname</code>, reformatted according to the generic 
 pathname format (<a href="#path.generic">8.1</a>).</p>


### PR DESCRIPTION
Standard string types must be qualified to disambiguate them from
member functions with the same names.
