### PR TITLE
Change "a absolute" to "an absolute"

### DIFF
--- a/working-draft.html
+++ b/working-draft.html
@@ -1346,7 +1346,7 @@ template &lt;class InputIterator&gt;
     Appends <code>path::preferred_separator</code> to <code>pathname</code> unless:<ul>
     <li para_num="4">an added separator 
     would be redundant, or</li>
-    <li para_num="5">would change a relative path to a absolute path
+    <li para_num="5">would change a relative path to an absolute path
     [<i>Note</i>: An empty path is relative. — <i>end note</i>], or</li>
     <li para_num="6"><code>p.empty()</code>, or</li>
     <li para_num="7"><code>*p.native().cbegin()</code> is a directory separator.</li>


### PR DESCRIPTION
This was introduced by an earlier edit fixing "an relative" but it also
incorrectly changed "an absolute".
