### PR TITLE
Update issue #65 - `remove_filename()` post condition is incorrect

### DIFF
--- a/issues/xml/issue0065.xml
+++ b/issues/xml/issue0065.xml
@@ -32,7 +32,7 @@ and <code>"/"</code> has a filename of <code>"/"</code>.</p>
     </p>
     <p/>
     <ins>
-      <i>Effects:</i> <code>*this = parent_path()</code>, except that if <code>parent_path() == root_path()</code>, <code>clear()</code>.
+      <i>Effects:</i> <code>*this = parent_path()</code>, except that if <code>parent_path() == root_name()</code>, <code>clear()</code>.
     </ins>
     <p>
       <i>Returns: </i> <code>*this</code>.


### PR DESCRIPTION
Hi Beman,

The current issue resolution says:

> Effects: *this = parent_path(), except that if parent_path() == root_path(), clear().

But this should say `root_name()` instead of `root_path()`. For example the breakdown of `/foo` is:
root_name = ""
root_path = "/"
parent_path = "/"

Using `root_name()` means that `path("/foo").remove_filename()` should call clear.
